### PR TITLE
refactor: use Label instead of hard assuming package name

### DIFF
--- a/spa/private/routes/generate_route_manifest.bzl
+++ b/spa/private/routes/generate_route_manifest.bzl
@@ -16,9 +16,9 @@ def generate_route_manifest(name, routes):
     nodejs_binary(
         name = "bin",
         data = [
-            "@rules_spa//spa/private/routes:generate-route-manifest.js",
+            Label("//spa/private/routes:generate-route-manifest.js"),
         ],
-        entry_point = "@rules_spa//spa/private/routes:generate-route-manifest.js",
+        entry_point = Label("//spa/private/routes:generate-route-manifest.js"),
     )
 
     npm_package_bin(


### PR DESCRIPTION
uses label instead of assumed repo path name

https://docs.bazel.build/versions/main/skylark/lib/Label.html