### PR TITLE
feat: move webpack configs from example repo

### DIFF
--- a/spa/private/routes/BUILD.bazel
+++ b/spa/private/routes/BUILD.bazel
@@ -2,6 +2,8 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 """Marks this as a package"""
 
+exports_files(["generate-route-manifest.js"])
+
 bzl_library(
     name = "generate_route_manifest",
     srcs = [
@@ -10,5 +12,3 @@ bzl_library(
     ],
     visibility = ["//spa:__subpackages__"],
 )
-
-exports_files(["generate-route-manifest.js"])

--- a/spa/private/webpack/BUILD.bazel
+++ b/spa/private/webpack/BUILD.bazel
@@ -1,0 +1,7 @@
+# Defines this as an importable module area for shared macros and configs
+exports_files([
+    "webpack.common.config.js",
+    "webpack.host.config.js",
+    "webpack.module-federation.shared.js",
+    "webpack.route.config.js",
+])

--- a/spa/private/webpack/webpack.common.config.js
+++ b/spa/private/webpack/webpack.common.config.js
@@ -1,0 +1,26 @@
+module.exports = ({ production }) => {
+  return {
+    cache: false,
+
+    mode: production ? "production" : "development",
+    devtool: "source-map",
+
+    optimization: {
+      minimize: false,
+    },
+
+    output: {
+      filename: production ? "[name].[contenthash].js" : "[name].js",
+      publicPath: "auto",
+      // crossOriginLoading: "anonymous",
+    },
+
+    resolve: {
+      extensions: [".jsx", ".js"],
+      fallback: {
+        // In the browser, let `path` be an empty module
+        path: false,
+      },
+    },
+  };
+};

--- a/spa/private/webpack/webpack.host.config.js
+++ b/spa/private/webpack/webpack.host.config.js
@@ -1,0 +1,32 @@
+const ModuleFederationPlugin =
+  require("webpack").container.ModuleFederationPlugin;
+const generateWebpackCommonConfig = require("./webpack.common.config");
+const shared = require("./webpack.module-federation.shared");
+
+/**
+ * Webpack configuration used to generate a unique route
+ *
+ * @param {Record<string, boolean|string}
+ * @returns {import('webpack').Configuration} a Webpack configuration
+ */
+module.exports = ({ entry, production }) => {
+  const commonConfig = generateWebpackCommonConfig({ production });
+
+  return {
+    entry,
+    ...commonConfig,
+    output: {
+      ...commonConfig.output,
+      filename: production ? `app.[name].[contenthash].js` : `app.[name].js`,
+    },
+    plugins: [
+      new ModuleFederationPlugin({
+        name: "app",
+        filename: "appEntry.js",
+        library: { type: "var", name: "app" },
+        remotes: {},
+        shared,
+      }),
+    ],
+  };
+};

--- a/spa/private/webpack/webpack.module-federation.shared.js
+++ b/spa/private/webpack/webpack.module-federation.shared.js
@@ -1,0 +1,18 @@
+// TODO: have this be generated based on a list of dependencies or a file provided
+// by the end user
+const deps = require("../../../../package.json").dependencies;
+module.exports = {
+  ...deps,
+  "react-router-dom": {
+    singleton: true,
+    eager: false,
+  },
+  "react-dom": {
+    singleton: true,
+    eager: false,
+  },
+  react: {
+    singleton: true,
+    eager: false,
+  },
+};

--- a/spa/private/webpack/webpack.route.config.js
+++ b/spa/private/webpack/webpack.route.config.js
@@ -1,0 +1,35 @@
+const ModuleFederationPlugin =
+  require("webpack").container.ModuleFederationPlugin;
+const generateWebpackCommonConfig = require("./webpack.common.config");
+const shared = require("./webpack.module-federation.shared");
+
+/**
+ * Webpack configuration used to generate a unique road
+ *
+ * @param {Record<string, boolean|string}
+ * @returns {import('webpack').Configuration} a Webpack configuration
+ */
+module.exports = ({ entry, production, name }) => {
+  const commonConfig = generateWebpackCommonConfig({ production });
+
+  return {
+    entry,
+    ...commonConfig,
+    output: {
+      ...commonConfig.output,
+      filename: production
+        ? `${name}.[name].[contenthash].js`
+        : `${name}.[name].js`,
+    },
+    plugins: [
+      new ModuleFederationPlugin({
+        name,
+        filename: "remoteEntry.[contenthash].js",
+        exposes: {
+          "./route": entry,
+        },
+        shared,
+      }),
+    ],
+  };
+};


### PR DESCRIPTION
These configs are the basis for the compilation process
Moving them before refactoring things to support them coming
from a rule