### PR TITLE
feature: migrate host config macro

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,6 +2,32 @@
 
 Public API re-exports
 
+<a id="#build_host"></a>
+
+## build_host
+
+<pre>
+build_host(<a href="#build_host-entry">entry</a>, <a href="#build_host-data">data</a>, <a href="#build_host-srcs">srcs</a>, <a href="#build_host-webpack">webpack</a>, <a href="#build_host-shared">shared</a>)
+</pre>
+
+    Macro that allows easy building of the main host of a SPA
+
+In addition to the usage of this macro, you will be required to pass in all required node_modules
+for compilation as well as anything the shared config relies on (most likely your package.json) into data
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="build_host-entry"></a>entry |  the entry file to the route   |  none |
+| <a id="build_host-data"></a>data |  any dependencies the route needs to build including npm modules   |  none |
+| <a id="build_host-srcs"></a>srcs |  srcs files to be transpiled and sent to webpack   |  none |
+| <a id="build_host-webpack"></a>webpack |  the webpack module to invoke. The users must provide their own load statement for webpack before this macro is called   |  none |
+| <a id="build_host-shared"></a>shared |  a nodejs module file that exposes a map of dependencies to their shared module spec https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints. An example of this is located within this repository under the private/webpack folder.   |  none |
+
+
 <a id="#build_route"></a>
 
 ## build_route

--- a/spa/BUILD.bazel
+++ b/spa/BUILD.bazel
@@ -30,6 +30,7 @@ bzl_library(
     deps = [
         "//spa/private:build_routes",
         "//spa/private:build_server",
+        "//spa/private:host",
         "//spa/private/routes:generate_route_manifest",
     ],
 )

--- a/spa/defs.bzl
+++ b/spa/defs.bzl
@@ -3,7 +3,9 @@
 load("//spa/private/routes:generate_route_manifest.bzl", _generate_route_manifest = "generate_route_manifest")
 load("//spa/private:build_routes.bzl", _build_route = "build_route")
 load("//spa/private:build_server.bzl", _build_server = "build_server")
+load("//spa/private:host.bzl", _build_host = "build_host")
 
 generate_route_manifest = _generate_route_manifest
 build_route = _build_route
 build_server = _build_server
+build_host = _build_host

--- a/spa/private/BUILD.bazel
+++ b/spa/private/BUILD.bazel
@@ -22,8 +22,6 @@ bzl_library(
     visibility = ["//spa:__subpackages__"],
     deps = [
         "@aspect_rules_swc//swc",
-        "@build_bazel_rules_nodejs//:index",
-        "@npm//webpack:index",
     ],
 )
 

--- a/spa/private/BUILD.bazel
+++ b/spa/private/BUILD.bazel
@@ -8,6 +8,26 @@ bzl_library(
 )
 
 bzl_library(
+    name = "build_server",
+    srcs = ["build_server.bzl"],
+    visibility = ["//spa:__subpackages__"],
+    deps = [
+        "@aspect_rules_swc//swc",
+    ],
+)
+
+bzl_library(
+    name = "host",
+    srcs = ["host.bzl"],
+    visibility = ["//spa:__subpackages__"],
+    deps = [
+        "@aspect_rules_swc//swc",
+        "@build_bazel_rules_nodejs//:index",
+        "@npm//webpack:index",
+    ],
+)
+
+bzl_library(
     name = "toolchains_repo",
     srcs = ["toolchains_repo.bzl"],
     visibility = ["//spa:__subpackages__"],
@@ -17,16 +37,4 @@ bzl_library(
     name = "versions",
     srcs = ["versions.bzl"],
     visibility = ["//spa:__subpackages__"],
-)
-
-bzl_library(
-    name = "build_server",
-    srcs = [
-        "build_server.bzl",
-        "@build_bazel_rules_nodejs//:bzl",
-    ],
-    visibility = ["//spa:__subpackages__"],
-    deps = [
-        "@aspect_rules_swc//swc",
-    ],
 )

--- a/spa/private/host.bzl
+++ b/spa/private/host.bzl
@@ -5,7 +5,7 @@ load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
 
 # Defines this as an importable module area for shared macros and configs
 
-def build_host(entry, data, srcs):
+def build_host(entry, data, srcs, webpack):
     """
     Macro that allows easy building of the main host of a SPA
 
@@ -13,9 +13,16 @@ def build_host(entry, data, srcs):
         entry: the entry file to the route
         data: any dependencies the route needs to build including npm modules
         srcs: srcs files to be transpiled and sent to webpack
-    NOTE: users must provide their own load statement for webpack before this macro is called
+        webpack: the webpack module to invoke. The users must provide their own load statement for webpack before this macro is called
     ```python
-    load("@npm//webpack:index.bzl", "webpack")
+    load("@npm//webpack-cli:index.bzl", "webpack_cli")
+
+    # ...
+
+    build_host(
+        ...
+        webpack=webpack_cli
+    )
     ```
     """
 
@@ -37,7 +44,7 @@ def build_host(entry, data, srcs):
         for s in srcs
     ]
 
-    host_config = Label("//spa/webpack:webpack.host.config.js")
+    host_config = Label("//spa/private/webpack:webpack.host.config.js")
     webpack(
         name = "host_build",
         args = [
@@ -47,8 +54,9 @@ def build_host(entry, data, srcs):
             "--config=$(rootpath %s)" % host_config,
         ],
         data = [
-            Label("//spa/webpack:webpack.host.config.js"),
-            Label("//spa/webpack:webpack.common.config.js"),
+            host_config,
+            Label("//spa/private/webpack:webpack.common.config.js"),
+            Label("//spa/private/webpack:webpack.module-federation.shared.js"),
         ] + deps,
         output_dir = True,
     )

--- a/spa/private/host.bzl
+++ b/spa/private/host.bzl
@@ -4,26 +4,19 @@ load("@aspect_rules_swc//swc:swc.bzl", "swc")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
 
 # Defines this as an importable module area for shared macros and configs
-
-def build_host(entry, data, srcs, webpack):
+def build_host(entry, data, srcs, webpack, shared):
     """
     Macro that allows easy building of the main host of a SPA
+
+    In addition to the usage of this macro, you will be required to pass in all required node_modules
+    for compilation as well as anything the shared config relies on (most likely your package.json) into data
 
     Args:
         entry: the entry file to the route
         data: any dependencies the route needs to build including npm modules
         srcs: srcs files to be transpiled and sent to webpack
         webpack: the webpack module to invoke. The users must provide their own load statement for webpack before this macro is called
-    ```python
-    load("@npm//webpack-cli:index.bzl", "webpack_cli")
-
-    # ...
-
-    build_host(
-        ...
-        webpack=webpack_cli
-    )
-    ```
+        shared: a nodejs module file that exposes a map of dependencies to their shared module spec https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints. An example of this is located within this repository under the private/webpack folder.
     """
 
     # list of all transpilation targets from SWC to be passed to webpack
@@ -50,11 +43,13 @@ def build_host(entry, data, srcs, webpack):
         args = [
             "--env name=host",
             "--env entry=./$(location :transpile_host)",
+            "--env SHARED_CONFIG=$(location %s)" % shared,
             "--output-path=$(@D)",
             "--config=$(rootpath %s)" % host_config,
         ],
         data = [
             host_config,
+            shared,
             Label("//spa/private/webpack:webpack.common.config.js"),
             Label("//spa/private/webpack:webpack.module-federation.shared.js"),
         ] + deps,

--- a/spa/private/host.bzl
+++ b/spa/private/host.bzl
@@ -1,6 +1,5 @@
 """A macro for creating a webpack federation host module"""
 
-load("@npm//webpack:index.bzl", "webpack")
 load("@aspect_rules_swc//swc:swc.bzl", "swc")
 load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
 
@@ -14,6 +13,10 @@ def build_host(entry, data, srcs):
         entry: the entry file to the route
         data: any dependencies the route needs to build including npm modules
         srcs: srcs files to be transpiled and sent to webpack
+    NOTE: users must provide their own load statement for webpack before this macro is called
+    ```python
+    load("@npm//webpack:index.bzl", "webpack")
+    ```
     """
 
     # list of all transpilation targets from SWC to be passed to webpack

--- a/spa/private/host.bzl
+++ b/spa/private/host.bzl
@@ -1,0 +1,60 @@
+"""A macro for creating a webpack federation host module"""
+
+load("@npm//webpack:index.bzl", "webpack")
+load("@aspect_rules_swc//swc:swc.bzl", "swc")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_web")
+
+# Defines this as an importable module area for shared macros and configs
+
+def build_host(entry, data, srcs):
+    """
+    Macro that allows easy building of the main host of a SPA
+
+    Args:
+        entry: the entry file to the route
+        data: any dependencies the route needs to build including npm modules
+        srcs: srcs files to be transpiled and sent to webpack
+    """
+
+    # list of all transpilation targets from SWC to be passed to webpack
+    deps = [
+        ":transpile_" + files.replace("//", "").replace("/", "_").split(".")[0]
+        for files in srcs
+    ] + data
+
+    # buildifier: disable=no-effect
+    [
+        swc(
+            name = "transpile_" + s.replace("/", "_").split(".")[0],
+            args = [
+                "-C jsc.parser.jsx=true",
+            ],
+            srcs = [s],
+        )
+        for s in srcs
+    ]
+
+    host_config = Label("//spa/webpack:webpack.host.config.js")
+    webpack(
+        name = "host_build",
+        args = [
+            "--env name=host",
+            "--env entry=./$(location :transpile_host)",
+            "--output-path=$(@D)",
+            "--config=$(rootpath %s)" % host_config,
+        ],
+        data = [
+            Label("//spa/webpack:webpack.host.config.js"),
+            Label("//spa/webpack:webpack.common.config.js"),
+        ] + deps,
+        output_dir = True,
+    )
+
+    pkg_web(
+        name = "host",
+        srcs = [
+            ":host_build",
+        ],
+        additional_root_paths = ["%s/host_build" % native.package_name()],
+        visibility = ["//visibility:public"],
+    )

--- a/spa/private/webpack/webpack.host.config.js
+++ b/spa/private/webpack/webpack.host.config.js
@@ -1,7 +1,7 @@
 const ModuleFederationPlugin =
   require("webpack").container.ModuleFederationPlugin;
 const generateWebpackCommonConfig = require("./webpack.common.config");
-const shared = require("./webpack.module-federation.shared");
+const path = require("path");
 
 /**
  * Webpack configuration used to generate a unique route
@@ -9,8 +9,10 @@ const shared = require("./webpack.module-federation.shared");
  * @param {Record<string, boolean|string}
  * @returns {import('webpack').Configuration} a Webpack configuration
  */
-module.exports = ({ entry, production }) => {
+module.exports = ({ entry, production, SHARED_CONFIG }) => {
   const commonConfig = generateWebpackCommonConfig({ production });
+  // This must be required by the end user for now
+  const shared = require(path.resolve(`${SHARED_CONFIG}`));
 
   return {
     entry,


### PR DESCRIPTION
This diff migrates the `host` macro from https://github.com/Aghassi/bazel-module-federation

Changes from the original include:

* The rules consumer must provide `package.json` and a `webpack.shared.dependencies.js` file that we require. The shared module list is a javascript object that abides by the config requirements of webpack https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints
* Users must provide their `node_modules` to the macro, it can't be inferred or assumed since the npm workspace may be named differently per project
* Users must provide `webpack` runner from their own `load` statement instead of the macro doing it for them. This is because of the prior problem where the npm workspace is unknown when the macro is being run

To test this change directly, pull this branch and https://github.com/Aghassi/bazel-module-federation/tree/example/use-with-rules-spa and edit the `.bazelrc` to locally link. Then you can run `bazel build //src/client/host` to test the build