### PR TITLE
feat: add build-routes macro from example app

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -2,6 +2,28 @@
 
 Public API re-exports
 
+<a id="#build_route"></a>
+
+## build_route
+
+<pre>
+build_route(<a href="#build_route-name">name</a>, <a href="#build_route-entry">entry</a>, <a href="#build_route-data">data</a>, <a href="#build_route-webpack">webpack</a>, <a href="#build_route-shared">shared</a>)
+</pre>
+
+    Macro that allows easy composition of routes from a multi route spa
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="build_route-name"></a>name |  name of a route (route)   |  none |
+| <a id="build_route-entry"></a>entry |  the entry file to the route   |  none |
+| <a id="build_route-data"></a>data |  any dependencies the route needs to build   |  none |
+| <a id="build_route-webpack"></a>webpack |  the webpack module to invoke. The users must provide their own load statement for webpack before this macro is called   |  none |
+| <a id="build_route-shared"></a>shared |  a nodejs module file that exposes a map of dependencies to their shared module spec https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints. An example of this is located within this repository under the private/webpack folder.   |  none |
+
+
 <a id="#generate_route_manifest"></a>
 
 ## generate_route_manifest

--- a/spa/BUILD.bazel
+++ b/spa/BUILD.bazel
@@ -27,7 +27,10 @@ bzl_library(
     name = "defs",
     srcs = ["defs.bzl"],
     visibility = ["//visibility:public"],
-    deps = ["//spa/private/routes:generate_route_manifest"],
+    deps = [
+        "//spa/private:build_routes",
+        "//spa/private/routes:generate_route_manifest",
+    ],
 )
 
 bzl_library(

--- a/spa/defs.bzl
+++ b/spa/defs.bzl
@@ -1,5 +1,7 @@
 "Public API re-exports"
 
 load("//spa/private/routes:generate_route_manifest.bzl", _generate_route_manifest = "generate_route_manifest")
+load("//spa/private:build_routes.bzl", _build_route = "build_route")
 
 generate_route_manifest = _generate_route_manifest
+build_route = _build_route

--- a/spa/private/BUILD.bazel
+++ b/spa/private/BUILD.bazel
@@ -1,6 +1,13 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 bzl_library(
+    name = "build_routes",
+    srcs = ["build_routes.bzl"],
+    visibility = ["//spa:__subpackages__"],
+    deps = ["@aspect_rules_swc//swc"],
+)
+
+bzl_library(
     name = "toolchains_repo",
     srcs = ["toolchains_repo.bzl"],
     visibility = ["//spa:__subpackages__"],

--- a/spa/private/build_routes.bzl
+++ b/spa/private/build_routes.bzl
@@ -1,0 +1,60 @@
+"""A macro for creating a webpack federation route module"""
+
+load("@aspect_rules_swc//swc:swc.bzl", "swc")
+
+# Defines this as an importable module area for shared macros and configs
+
+def build_route(name, entry, data, webpack, shared):
+    """
+    Macro that allows easy composition of routes from a multi route spa
+
+    Args:
+        name: name of a route (route)
+        entry: the entry file to the route
+        data: any dependencies the route needs to build
+        webpack: the webpack module to invoke. The users must provide their own load statement for webpack before this macro is called
+        shared: a nodejs module file that exposes a map of dependencies to their shared module spec https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints. An example of this is located within this repository under the private/webpack folder.
+    """
+
+    build_name = name + "_route"
+
+    # list of all transpilation targets from SWC to be passed to webpack
+    deps = [
+        ":transpile_" + files.replace("//", "").replace("/", "_").split(".")[0]
+        for files in data
+    ]
+
+    # buildifier: disable=no-effect
+    [
+        swc(
+            name = "transpile_" + s.replace("//", "").replace("/", "_").split(".")[0],
+            args = [
+                "-C jsc.parser.jsx=true",
+                "-C jsc.parser.typescript=true",
+                "-C jsc.transform.react.runtime=automatic",
+                "-C jsc.transform.react.development=false",
+                "-C module.type=commonjs",
+            ],
+            srcs = [s],
+        )
+        for s in data
+    ]
+
+    route_config = Label("//spa/private/webpack:webpack.route.config.js")
+    webpack(
+        name = name,
+        args = [
+            "--env name=" + build_name,
+            "--env entry=./$(execpath :transpile_" + name + ")",
+            "--env SHARED_CONFIG=$(location %s)" % shared,
+            "--output-path=$(@D)",
+            "--config=$(rootpath //bazel/js/internals/webpack:route_config)",
+        ],
+        data = [
+            route_config,
+            shared,
+            Label("//spa/private/webpack:webpack.common.config.js"),
+        ] + deps,
+        output_dir = True,
+        visibility = ["//src/client/routes:__pkg__"],
+    )

--- a/spa/private/webpack/webpack.route.config.js
+++ b/spa/private/webpack/webpack.route.config.js
@@ -1,7 +1,7 @@
 const ModuleFederationPlugin =
   require("webpack").container.ModuleFederationPlugin;
 const generateWebpackCommonConfig = require("./webpack.common.config");
-const shared = require("./webpack.module-federation.shared");
+const path = require("path");
 
 /**
  * Webpack configuration used to generate a unique road
@@ -9,8 +9,10 @@ const shared = require("./webpack.module-federation.shared");
  * @param {Record<string, boolean|string}
  * @returns {import('webpack').Configuration} a Webpack configuration
  */
-module.exports = ({ entry, production, name }) => {
+module.exports = ({ entry, production, name, SHARED_CONFIG }) => {
   const commonConfig = generateWebpackCommonConfig({ production });
+  // This must be required by the end user for now
+  const shared = require(path.resolve(`${SHARED_CONFIG}`));
 
   return {
     entry,


### PR DESCRIPTION
This change also refactors the macro to force the user
to provide their webpack runner and shared modules config
instead of the macro making assumptions around it.
Users must also provide labels to their node_modules

This follows #7 in migrating existing macros from the example repo here to be consumed back there