### PR TITLE
feat: add build_server macro from example repo

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -24,6 +24,27 @@ build_route(<a href="#build_route-name">name</a>, <a href="#build_route-entry">e
 | <a id="build_route-shared"></a>shared |  a nodejs module file that exposes a map of dependencies to their shared module spec https://webpack.js.org/plugins/module-federation-plugin/#sharing-hints. An example of this is located within this repository under the private/webpack folder.   |  none |
 
 
+<a id="#build_server"></a>
+
+## build_server
+
+<pre>
+build_server(<a href="#build_server-name">name</a>, <a href="#build_server-srcs">srcs</a>, <a href="#build_server-data">data</a>, <a href="#build_server-kwargs">kwargs</a>)
+</pre>
+
+    Macro that construct the http server for the project
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="build_server-name"></a>name |  name of the package   |  none |
+| <a id="build_server-srcs"></a>srcs |  source files from the package   |  none |
+| <a id="build_server-data"></a>data |  any dependencies needed to build   |  none |
+| <a id="build_server-kwargs"></a>kwargs |  any other inputs to js_library   |  none |
+
+
 <a id="#generate_route_manifest"></a>
 
 ## generate_route_manifest

--- a/spa/BUILD.bazel
+++ b/spa/BUILD.bazel
@@ -29,6 +29,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "//spa/private:build_routes",
+        "//spa/private:build_server",
         "//spa/private/routes:generate_route_manifest",
     ],
 )

--- a/spa/defs.bzl
+++ b/spa/defs.bzl
@@ -2,6 +2,8 @@
 
 load("//spa/private/routes:generate_route_manifest.bzl", _generate_route_manifest = "generate_route_manifest")
 load("//spa/private:build_routes.bzl", _build_route = "build_route")
+load("//spa/private:build_server.bzl", _build_server = "build_server")
 
 generate_route_manifest = _generate_route_manifest
 build_route = _build_route
+build_server = _build_server

--- a/spa/private/BUILD.bazel
+++ b/spa/private/BUILD.bazel
@@ -18,3 +18,15 @@ bzl_library(
     srcs = ["versions.bzl"],
     visibility = ["//spa:__subpackages__"],
 )
+
+bzl_library(
+    name = "build_server",
+    srcs = [
+        "build_server.bzl",
+        "@build_bazel_rules_nodejs//:bzl",
+    ],
+    visibility = ["//spa:__subpackages__"],
+    deps = [
+        "@aspect_rules_swc//swc",
+    ],
+)

--- a/spa/private/build_server.bzl
+++ b/spa/private/build_server.bzl
@@ -1,0 +1,44 @@
+"""A macro for building the server bundle that will end up in a nodejs docker image"""
+
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("@aspect_rules_swc//swc:swc.bzl", "swc")
+
+# Defines this as an importable module area for shared macros and configs
+
+def build_server(name, srcs, data, **kwargs):
+    """
+    Macro that construct the http server for the project
+
+    Args:
+        name: name of the package
+        srcs: source files from the package
+        data: any dependencies needed to build
+        **kwargs: any other inputs to js_library
+    """
+
+    # list of all transpilation targets from SWC to be passed to webpack
+    deps = [
+        ":transpile_" + files.replace("//", "").replace("/", "_").split(".")[0]
+        for files in srcs
+    ]
+
+    # buildifier: disable=no-effect
+    [
+        swc(
+            name = "transpile_" + s.replace("//", "").replace("/", "_").split(".")[0],
+            args = [
+                "-C jsc.parser.jsx=true",
+                "-C jsc.parser.syntax=typescript",
+                "-C jsc.target=es2015",
+                "-C module.type=commonjs",
+            ],
+            srcs = [s],
+        )
+        for s in srcs
+    ]
+
+    js_library(
+        name = name,
+        srcs = deps + data,
+        **kwargs
+    )


### PR DESCRIPTION
This macro has minimal changes, mostly some documentation fix ups
This should be a drop in curover as this basically just uses
other rules and doesn't do any webpack processing