### PR TITLE
fix: compile ts for all paths

### DIFF
--- a/spa/private/build_routes.bzl
+++ b/spa/private/build_routes.bzl
@@ -31,7 +31,7 @@ def build_route(name, entry, srcs, data, webpack, shared):
             name = "transpile_" + s.replace("//", "").replace("/", "_").split(".")[0],
             args = [
                 "-C jsc.parser.jsx=true",
-                "-C jsc.parser.typescript=true",
+                "-C jsc.parser.syntax=typescript",
                 "-C jsc.transform.react.runtime=automatic",
                 "-C jsc.transform.react.development=false",
                 "-C module.type=commonjs",

--- a/spa/private/host.bzl
+++ b/spa/private/host.bzl
@@ -31,6 +31,7 @@ def build_host(entry, data, srcs, webpack, shared):
             name = "transpile_" + s.replace("/", "_").split(".")[0],
             args = [
                 "-C jsc.parser.jsx=true",
+                "-C jsc.parser.syntax=typescript",
             ],
             srcs = [s],
         )


### PR DESCRIPTION
This change solves for the current limitation where our routes cannot parse and compile typescript types.