### PR TITLE
feat: enforce module scope plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A set of macros and rules to support building a **S**ingle **P**age **A**rchitec
 
 **Please be advised this rule set is in very preliminary development and may break at anytime between changes.**
 
-_NOTE:_ This rule set depends on `webpack` via installation of `npm` with `rules_nodejs`. This currently is not encoded into the Bazel graph, so be sure to bring your own version (must be v5 or higher)
+_NOTE:_ This rule set depends on `webpack` (v5+) and `react-dev-utils` via installation of `npm` with `rules_nodejs`. This currently is not encoded into the Bazel graph, so be sure to bring your own versions.
 
 ## Installation
 

--- a/spa/private/build_routes.bzl
+++ b/spa/private/build_routes.bzl
@@ -48,6 +48,7 @@ def build_route(name, entry, srcs, data, webpack, federation_shared_config):
             "--env name=" + build_name,
             "--env entry=./$(execpath :transpile_" + name + ")",
             "--env SHARED_CONFIG=$(location %s)" % federation_shared_config,
+            "--env BAZEL_SRC_PATH=$(execpath)",
             "--output-path=$(@D)",
             "--config=$(rootpath %s)" % route_config,
         ],

--- a/spa/private/build_routes.bzl
+++ b/spa/private/build_routes.bzl
@@ -48,7 +48,7 @@ def build_route(name, entry, srcs, data, webpack, federation_shared_config):
             "--env name=" + build_name,
             "--env entry=./$(execpath :transpile_" + name + ")",
             "--env SHARED_CONFIG=$(location %s)" % federation_shared_config,
-            "--env BAZEL_SRC_PATH=$(execpath)",
+            "--env BAZEL_SRC_PATH=$(execpath :transpile_)" + name + ")",
             "--output-path=$(@D)",
             "--config=$(rootpath %s)" % route_config,
         ],

--- a/spa/private/host.bzl
+++ b/spa/private/host.bzl
@@ -45,7 +45,7 @@ def build_host(entry, data, srcs, webpack, federation_shared_config):
             "--env name=host",
             "--env entry=./$(location :transpile_host)",
             "--env SHARED_CONFIG=$(location %s)" % federation_shared_config,
-            "--env BAZEL_SRC_PATH=$(execpath)",
+            "--env BAZEL_SRC_PATH=$(execpath :transpile_host)",
             "--output-path=$(@D)",
             "--config=$(rootpath %s)" % host_config,
         ],

--- a/spa/private/host.bzl
+++ b/spa/private/host.bzl
@@ -45,6 +45,7 @@ def build_host(entry, data, srcs, webpack, federation_shared_config):
             "--env name=host",
             "--env entry=./$(location :transpile_host)",
             "--env SHARED_CONFIG=$(location %s)" % federation_shared_config,
+            "--env BAZEL_SRC_PATH=$(execpath)",
             "--output-path=$(@D)",
             "--config=$(rootpath %s)" % host_config,
         ],

--- a/spa/private/webpack/webpack.common.config.js
+++ b/spa/private/webpack/webpack.common.config.js
@@ -24,7 +24,9 @@ module.exports = ({ production, BAZEL_SRC_PATH }) => {
         // In the browser, let `path` be an empty module
         path: false,
       },
+      plugins: [
+        new ModuleScopePlugin(path.resolve(path.dirname(BAZEL_SRC_PATH)), []),
+      ],
     },
-    plugins: [new ModuleScopePlugin(path.resolve(BAZEL_SRC_PATH, "/src"))],
   };
 };

--- a/spa/private/webpack/webpack.common.config.js
+++ b/spa/private/webpack/webpack.common.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 
 module.exports = ({ production, BAZEL_SRC_PATH }) => {
@@ -24,6 +25,6 @@ module.exports = ({ production, BAZEL_SRC_PATH }) => {
         path: false,
       },
     },
-    plugins: [new ModuleScopePlugin(BAZEL_SRC_PATH)],
+    plugins: [new ModuleScopePlugin(path.resolve(BAZEL_SRC_PATH, "/src"))],
   };
 };

--- a/spa/private/webpack/webpack.common.config.js
+++ b/spa/private/webpack/webpack.common.config.js
@@ -1,6 +1,6 @@
 const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
 
-module.exports = ({ production }) => {
+module.exports = ({ production, BAZEL_SRC_PATH }) => {
   return {
     cache: false,
 
@@ -24,6 +24,6 @@ module.exports = ({ production }) => {
         path: false,
       },
     },
-    plugins: [new ModuleScopePlugin()],
+    plugins: [new ModuleScopePlugin(BAZEL_SRC_PATH)],
   };
 };

--- a/spa/private/webpack/webpack.common.config.js
+++ b/spa/private/webpack/webpack.common.config.js
@@ -1,3 +1,5 @@
+const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
+
 module.exports = ({ production }) => {
   return {
     cache: false,
@@ -22,5 +24,6 @@ module.exports = ({ production }) => {
         path: false,
       },
     },
+    plugins: [new ModuleScopePlugin()],
   };
 };

--- a/spa/private/webpack/webpack.host.config.js
+++ b/spa/private/webpack/webpack.host.config.js
@@ -9,8 +9,11 @@ const path = require("path");
  * @param {Record<string, boolean|string}
  * @returns {import('webpack').Configuration} a Webpack configuration
  */
-module.exports = ({ entry, production, SHARED_CONFIG }) => {
-  const commonConfig = generateWebpackCommonConfig({ production });
+module.exports = ({ entry, production, SHARED_CONFIG, BAZEL_SRC_PATH }) => {
+  const commonConfig = generateWebpackCommonConfig({
+    production,
+    BAZEL_SRC_PATH,
+  });
   // This must be required by the end user for now
   const shared = require(path.resolve(`${SHARED_CONFIG}`));
 

--- a/spa/private/webpack/webpack.host.config.js
+++ b/spa/private/webpack/webpack.host.config.js
@@ -22,6 +22,7 @@ module.exports = ({ entry, production, SHARED_CONFIG }) => {
       filename: production ? `app.[name].[contenthash].js` : `app.[name].js`,
     },
     plugins: [
+      ...commonConfig.plugins,
       new ModuleFederationPlugin({
         name: "app",
         filename: "appEntry.js",

--- a/spa/private/webpack/webpack.host.config.js
+++ b/spa/private/webpack/webpack.host.config.js
@@ -25,7 +25,6 @@ module.exports = ({ entry, production, SHARED_CONFIG, BAZEL_SRC_PATH }) => {
       filename: production ? `app.[name].[contenthash].js` : `app.[name].js`,
     },
     plugins: [
-      ...commonConfig.plugins,
       new ModuleFederationPlugin({
         name: "app",
         filename: "appEntry.js",

--- a/spa/private/webpack/webpack.route.config.js
+++ b/spa/private/webpack/webpack.route.config.js
@@ -9,8 +9,17 @@ const path = require("path");
  * @param {Record<string, boolean|string}
  * @returns {import('webpack').Configuration} a Webpack configuration
  */
-module.exports = ({ entry, production, name, SHARED_CONFIG }) => {
-  const commonConfig = generateWebpackCommonConfig({ production });
+module.exports = ({
+  entry,
+  production,
+  name,
+  SHARED_CONFIG,
+  BAZEL_SRC_PATH,
+}) => {
+  const commonConfig = generateWebpackCommonConfig({
+    production,
+    BAZEL_SRC_PATH,
+  });
   // This must be required by the end user for now
   const shared = require(path.resolve(`${SHARED_CONFIG}`));
 

--- a/spa/private/webpack/webpack.route.config.js
+++ b/spa/private/webpack/webpack.route.config.js
@@ -24,6 +24,7 @@ module.exports = ({ entry, production, name, SHARED_CONFIG }) => {
         : `${name}.[name].js`,
     },
     plugins: [
+      ...commonConfig.plugins,
       new ModuleFederationPlugin({
         name,
         filename: "remoteEntry.[contenthash].js",

--- a/spa/private/webpack/webpack.route.config.js
+++ b/spa/private/webpack/webpack.route.config.js
@@ -33,7 +33,6 @@ module.exports = ({
         : `${name}.[name].js`,
     },
     plugins: [
-      ...commonConfig.plugins,
       new ModuleFederationPlugin({
         name,
         filename: "remoteEntry.[contenthash].js",


### PR DESCRIPTION
- feat: add ModuleScopePlugin
- chore: expose the exec path to webpack plugin
- refactor: add src/ folder to execpath
- refactor: ensure the plugin is in the resolve part of webpack config

I opened a discussion over here regarding customer error handling https://github.com/facebook/create-react-app/discussions/11977 and created a draft PR for it here https://github.com/facebook/create-react-app/pull/11978

Example of successful build today
```sh
bazel-module-federation on  main [$!] via ⬢ v16.13.0 on 🐳 v20.10.11 took 5s
➜ bazel build //src/client/host
INFO: Analyzed target //src/client/host:host (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
INFO: From Action src/client/host/host_build:
assets by chunk 1.04 MiB (id hint: vendors)
  asset app.vendors-node_modules_react-dom_index_js.js 905 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_react_index_js.js 73.7 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_react-router_index_js.js 36.4 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_react-router-dom_index_js.js 26 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_regenerator-runtime_runtime_js.js 24.7 KiB [emitted] (id hint: vendors) 1 related asset
asset app.main.js 29 KiB [emitted] (name: main) 1 related asset
asset app.bazel-out_darwin_arm64-fastbuild_bin_src_client_host_bootstrap_js.js 18.2 KiB [emitted] 1 related asset
asset app.node_modules_history_index_js.js 9.39 KiB [emitted] 1 related asset
runtime modules 21 KiB 12 modules
built modules 1.04 MiB (javascript) 252 bytes (consume-shared) 210 bytes (share-init) [built]
  cacheable modules 1.04 MiB
    modules by path ./node_modules/ 1.03 MiB
      modules by path ./node_modules/scheduler/ 26.3 KiB 4 modules
      modules by path ./node_modules/react-dom/ 875 KiB 2 modules
      modules by path ./node_modules/react/ 70.6 KiB 2 modules
    modules by path ./bazel-out/darwin_arm64-fastbuild/bin/src/client/host/ 8.93 KiB 5 modules
  consume-shared-module modules 252 bytes 6 modules
  provide-module modules 210 bytes
    provide shared module (default) react-dom@17.0.2 = ./node_modules/react-dom/index.js 42 bytes [built] [code generated]
    provide shared module (default) react-router-dom@6.1.1 = ./node_modules/react-router-dom/index.js 42 bytes [built] [code generated]
    provide shared module (default) react-router@6.1.1 = ./node_modules/react-router/index.js 42 bytes [built] [code generated]
    provide shared module (default) react@17.0.2 = ./node_modules/react/index.js 42 bytes [built] [code generated]
    provide shared module (default) regenerator-runtime@0.13.9 = ./node_modules/regenerator-runtime/runtime.js 42 bytes [built] [code generated]

LOG from webpack.FileSystemInfo
<w> Managed item /private/var/tmp/_bazel_davidaghassi/bb7da84b9ecf678e9823437c8f5a423f/sandbox/darwin-sandbox/51/execroot/bazel_module_federation/node_modules/@carto/utils isn't a directory or doesn't contain a package.json
+ 11 hidden lines

webpack 5.60.0 compiled successfully in 486 ms
Target //src/client/host:host up-to-date:
  bazel-bin/src/client/host/host
INFO: Elapsed time: 3.210s, Critical Path: 2.94s
INFO: 2 processes: 1 internal, 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
```

Example of failure build by having `host` depend on `data` provided by a file from `routes`
```sh
bazel-module-federation on  main [$!] via ⬢ v16.13.0 on 🐳 v20.10.11
➜ bazel build //src/client/host
INFO: Analyzed target //src/client/host:host (2 packages loaded, 13 targets configured).
INFO: Found 1 target...
ERROR: /Users/davidaghassi/git/bazel-module-federation/src/client/host/BUILD.bazel:4:11: Action src/client/host/host_build failed: (Exit 1): webpack-cli.sh failed: error executing command bazel-out/host/bin/external/npm/webpack-cli/bin/webpack-cli.sh --env 'name=host' --env 'entry=./bazel-out/darwin_arm64-fastbuild/bin/src/client/host/host.js' --env ... (remaining 6 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
assets by chunk 1.04 MiB (id hint: vendors)
  asset app.vendors-node_modules_react-dom_index_js.js 905 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_react_index_js.js 73.7 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_react-router_index_js.js 36.4 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_react-router-dom_index_js.js 26 KiB [emitted] (id hint: vendors) 1 related asset
  asset app.vendors-node_modules_regenerator-runtime_runtime_js.js 24.7 KiB [emitted] (id hint: vendors) 1 related asset
asset app.main.js 29.2 KiB [emitted] (name: main) 1 related asset
asset app.bazel-out_darwin_arm64-fastbuild_bin_src_client_host_bootstrap_js.js 18.2 KiB [emitted] 1 related asset
asset app.node_modules_history_index_js.js 9.39 KiB [emitted] 1 related asset
runtime modules 21 KiB 12 modules
built modules 1.04 MiB (javascript) 252 bytes (consume-shared) 210 bytes (share-init) [built]
  cacheable modules 1.04 MiB
    modules by path ./node_modules/ 1.03 MiB
      modules by path ./node_modules/scheduler/ 26.3 KiB 4 modules
      modules by path ./node_modules/react-dom/ 875 KiB 2 modules
      modules by path ./node_modules/react/ 70.6 KiB 2 modules
    modules by path ./bazel-out/darwin_arm64-fastbuild/bin/src/client/host/ 8.96 KiB 5 modules
  consume-shared-module modules 252 bytes 6 modules
  provide-module modules 210 bytes
    provide shared module (default) react-dom@17.0.2 = ./node_modules/react-dom/index.js 42 bytes [built] [code generated]
    provide shared module (default) react-router-dom@6.1.1 = ./node_modules/react-router-dom/index.js 42 bytes [built] [code generated]
    provide shared module (default) react-router@6.1.1 = ./node_modules/react-router/index.js 42 bytes [built] [code generated]
    provide shared module (default) react@17.0.2 = ./node_modules/react/index.js 42 bytes [built] [code generated]
    provide shared module (default) regenerator-runtime@0.13.9 = ./node_modules/regenerator-runtime/runtime.js 42 bytes [built] [code generated]

LOG from webpack.FileSystemInfo
<w> Managed item /private/var/tmp/_bazel_davidaghassi/bb7da84b9ecf678e9823437c8f5a423f/sandbox/darwin-sandbox/53/execroot/bazel_module_federation/node_modules/@carto/utils isn't a directory or doesn't contain a package.json
+ 11 hidden lines

ERROR in ./bazel-out/darwin_arm64-fastbuild/bin/src/client/host/host.js 2:0-27
Module not found: Error: You attempted to import ../routes/default which falls outside of the project src/ directory. Relative imports outside of src/ are not supported.
You can either move it inside src/, or add a symlink to it from project's node_modules/.

webpack 5.60.0 compiled with 1 error in 491 ms
Target //src/client/host:host failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 3.888s, Critical Path: 3.48s
INFO: 3 processes: 2 internal, 1 darwin-sandbox.
FAILED: Build did NOT complete successfully
```

Obviously the error messaging needs some workshopping but still.